### PR TITLE
Bump versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# build
+*.tar.gz
+dependency-reduced-pom.xml
+scratch
+target
+
+# eclipse
+.classpath
+.project
+.settings
+
+# idea
+.idea
+*.iml
+*.iws
+*.ipr
+
+# mac
+*.DS_Store
+
+
+*.dat

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,25 @@
+pipeline {
+    agent { label 'maven-36-jdk11' }
+    stages {
+        stage('Prepare') {
+            steps {
+                sh 'printenv'
+            }
+        }
+        stage('Build') {
+            when {
+                expression { env.CHANGE_ID != null } // Pull request
+            }
+            steps {
+                sh '${M2_HOME}/bin/mvn -B -V clean verify'
+            }
+        }
+        stage('Deploy') {
+            when { branch 'main' }
+            steps {
+                echo "Deploy"
+                sh '${M2_HOME}/bin/mvn help:effective-settings -B -V clean deploy -e'
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
             }
         }
         stage('Deploy') {
-            when { branch 'main' }
+            when { branch 'master' }
             steps {
                 echo "Deploy"
                 sh '${M2_HOME}/bin/mvn help:effective-settings -B -V clean deploy -e'
@@ -23,3 +23,4 @@ pipeline {
         }
     }
 }
+

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,10 @@
   
   <properties>
     <projectOwner>Red Hat, Inc.</projectOwner>
-    <javaVersion>1.8</javaVersion>
+    <projectEmail>http://github.com/Commonjava/http-testserver</projectEmail>
+    <javaVersion>11</javaVersion>
     <undertowVersion>1.1.2.Final</undertowVersion>
+    <slf4j.versoin>1.7.25</slf4j.versoin>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+    Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava</groupId>
     <artifactId>commonjava</artifactId>
-    <version>11</version>
+    <version>18</version>
   </parent>
 
   <groupId>org.commonjava.util</groupId>
@@ -29,7 +29,7 @@
   <version>1.5-SNAPSHOT</version>
 
   <name>http-testserver</name>
-  <inceptionYear>2015</inceptionYear>
+  <inceptionYear>2015-2022</inceptionYear>
   
   <scm>
     <connection>scm:git:https://github.com/Commonjava/http-testserver.git</connection>
@@ -42,7 +42,7 @@
     <projectOwner>Red Hat, Inc.</projectOwner>
     <projectEmail>http://github.com/Commonjava/http-testserver</projectEmail>
     <javaVersion>11</javaVersion>
-    <undertowVersion>1.1.2.Final</undertowVersion>
+    <undertowVersion>2.2.26.Final</undertowVersion>
     <slf4j.versoin>1.7.25</slf4j.versoin>
   </properties>
 
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>org.commonjava.boms</groupId>
         <artifactId>web-commons-bom</artifactId>
-        <version>16</version>
+        <version>26</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -64,6 +64,11 @@
         <groupId>io.undertow</groupId>
         <artifactId>undertow-servlet</artifactId>
         <version>${undertowVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+        <version>3.4.0.Final</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/org/commonjava/test/http/TestHttpServer.java
+++ b/src/main/java/org/commonjava/test/http/TestHttpServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/common/CommonMethod.java
+++ b/src/main/java/org/commonjava/test/http/common/CommonMethod.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/common/HttpServerFixture.java
+++ b/src/main/java/org/commonjava/test/http/common/HttpServerFixture.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/expect/ContentResponse.java
+++ b/src/main/java/org/commonjava/test/http/expect/ContentResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/expect/ExpectationHandler.java
+++ b/src/main/java/org/commonjava/test/http/expect/ExpectationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/expect/ExpectationServer.java
+++ b/src/main/java/org/commonjava/test/http/expect/ExpectationServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/expect/ExpectationServlet.java
+++ b/src/main/java/org/commonjava/test/http/expect/ExpectationServlet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/stream/FileResolver.java
+++ b/src/main/java/org/commonjava/test/http/stream/FileResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/stream/JarFileResolver.java
+++ b/src/main/java/org/commonjava/test/http/stream/JarFileResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/stream/StreamResolver.java
+++ b/src/main/java/org/commonjava/test/http/stream/StreamResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/stream/StreamServer.java
+++ b/src/main/java/org/commonjava/test/http/stream/StreamServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/stream/StreamServlet.java
+++ b/src/main/java/org/commonjava/test/http/stream/StreamServlet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/util/PortFinder.java
+++ b/src/main/java/org/commonjava/test/http/util/PortFinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/util/StreamUtils.java
+++ b/src/main/java/org/commonjava/test/http/util/StreamUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/commonjava/test/http/util/UrlUtils.java
+++ b/src/main/java/org/commonjava/test/http/util/UrlUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/commonjava/test/http/TestHttpServerTest.java
+++ b/src/test/java/org/commonjava/test/http/TestHttpServerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
* slf4j -> 1.7.25
* undertow -> 2.2.26.Final
* web-commons-bom -> 26
* commonjava -> 18

And update interceptionYear with license header changes.