### PR TITLE
Take query params into account in expectation

### DIFF
--- a/src/main/java/org/commonjava/test/http/expect/ExpectationServlet.java
+++ b/src/main/java/org/commonjava/test/http/expect/ExpectationServlet.java
@@ -98,19 +98,17 @@ public final class ExpectationServlet
         return method.toUpperCase() + " " + path;
     }
 
-    private String getPath( final String path )
+    private String getPath( final String testUrl )
     {
-        String realPath = path;
         try
         {
-            final URL u = new URL( path );
-            realPath = u.getPath();
+            return new URL( testUrl ).getFile(); // path plus query parameters
         }
         catch ( final MalformedURLException e )
         {
+            e.printStackTrace();
         }
-
-        return realPath;
+        return testUrl;
     }
 
     public void expect( final String method, final String testUrl, final int responseCode, final String body )
@@ -147,22 +145,8 @@ public final class ExpectationServlet
     protected void service( final HttpServletRequest req, final HttpServletResponse resp )
         throws ServletException, IOException
     {
-        String wholePath;
-        try
-        {
-            wholePath = new URI( req.getRequestURI() ).getPath();
-        }
-        catch ( final URISyntaxException e )
-        {
-            throw new ServletException( "Cannot parse request URI", e );
-        }
 
-        String path = wholePath;
-        if ( path.length() > 1 )
-        {
-            path = path.substring( 1 );
-        }
-
+        String wholePath = getWholePath( req );
         final String key = getAccessKey( req.getMethod(), wholePath );
 
         logger.info( "Looking up expectation for: {}", key );
@@ -242,6 +226,21 @@ public final class ExpectationServlet
         }
 
         resp.setStatus( 404 );
+    }
+
+    private String getWholePath( HttpServletRequest request )
+    {
+        String requestURI = request.getRequestURI();
+        String queryString = request.getQueryString();
+
+        if ( queryString == null )
+        {
+            return requestURI;
+        }
+        else
+        {
+            return requestURI + "?" + queryString;
+        }
     }
 
     public String getAccessKey( final CommonMethod method, final String path )

--- a/src/test/java/org/commonjava/test/http/expect/ExpectationServerTest.java
+++ b/src/test/java/org/commonjava/test/http/expect/ExpectationServerTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2015-2022 Red Hat, Inc. (http://github.com/Commonjava/http-testserver)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.test.http.expect;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.commonjava.test.http.common.CommonMethod;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ExpectationServerTest
+{
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer( "repos" );
+
+    private final String subPath = "/path/to/something";
+
+    @Test
+    public void downloadWithQueryParams()
+            throws Exception
+    {
+        final String path1 = subPath + "?version=1.0";
+        final String path2 = subPath + "?version=2.0";
+
+        final String url1 = server.formatUrl(path1);
+        final String url2 = server.formatUrl(path2);
+
+        final String content1 = "this is a test version 1";
+        final String content2 = "this is a test version 2";
+
+        server.expect(url1, 200, content1);
+        server.expect(url2, 200, content2);
+
+        String result = getHttpContent(url1);
+        assertThat(result, equalTo(content1));
+
+        result = getHttpContent(url2);
+        assertThat(result, equalTo(content2));
+
+    }
+
+    private String getHttpContent(String url) throws IOException
+    {
+        final HttpGet request = new HttpGet( url );
+        final CloseableHttpClient client = HttpClients.createDefault();
+
+        try(CloseableHttpResponse response = client.execute( request ))
+        {
+            InputStream stream = response.getEntity().getContent();
+            return IOUtils.toString( stream );
+        }
+        finally
+        {
+            IOUtils.closeQuietly( client );
+        }
+    }
+}


### PR DESCRIPTION
Support path+query as 'whole path' when building expectations.